### PR TITLE
Fix data corruption when transferring ArrayBuffer from Java to JS

### DIFF
--- a/src/android/com/knowledgecode/cordova/websocket/WebSocketGenerator.java
+++ b/src/android/com/knowledgecode/cordova/websocket/WebSocketGenerator.java
@@ -18,7 +18,7 @@
  */
 package com.knowledgecode.cordova.websocket;
 
-import java.nio.charset.Charset;
+import java.util.Arrays;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.PluginResult.Status;
@@ -37,7 +37,6 @@ class WebSocketGenerator implements
 
     private final int _id;
     private final CallbackContext _ctx;
-    private final Charset _iso88591;
     private OnOpenListener _openListener;
     private OnCloseListener _closeListener;
 
@@ -50,7 +49,6 @@ class WebSocketGenerator implements
     public WebSocketGenerator(int id, CallbackContext ctx) {
         _id = id;
         _ctx = ctx;
-        _iso88591 = Charset.forName("ISO-8859-1");
         _openListener = new OnOpenListener() {
             @Override
             public void onOpen(int id, Connection conn) {
@@ -99,7 +97,8 @@ class WebSocketGenerator implements
 
     @Override
     public void onMessage(byte[] data, int offset, int length) {
-        sendCallback("B" + new String(data, _iso88591), true);
+        byte[] content = Arrays.copyOfRange(data, offset, offset+length);
+        sendCallback(content, true);
     }
 
     @Override
@@ -120,6 +119,20 @@ class WebSocketGenerator implements
     private void sendCallback(String callbackString, boolean keepCallback) {
         if (!_ctx.isFinished()) {
             PluginResult result = new PluginResult(Status.OK, callbackString);
+            result.setKeepCallback(keepCallback);
+            _ctx.sendPluginResult(result);
+        }
+    }
+
+    /**
+     * Send plugin result (ArrayBuffer)
+     *
+     * @param callbackBytes
+     * @param keepCallback
+     */
+    private void sendCallback(byte[] callbackBytes, boolean keepCallback) {
+        if (!_ctx.isFinished()) {
+            PluginResult result = new PluginResult(Status.OK, callbackBytes);
             result.setKeepCallback(keepCallback);
             _ctx.sendPluginResult(result);
         }

--- a/www/websocket.js
+++ b/www/websocket.js
@@ -198,51 +198,52 @@
             listeners[id] = {};
 
             exec(function (data) {
-                switch (data[0]) {
-                case 'O':
+                if (data instanceof ArrayBuffer) {
                     taskQueue.push(function () {
-                        var evt = createMessage('open');
-
-                        that.readyState = that.OPEN;
-                        that.protocol = data.substring(1);
-                        if (that.onopen) {
-                            that.onopen(evt);
-                        }
-                        that.dispatchEvent(evt);
-                    });
-                    break;
-                case 'T':
-                    taskQueue.push(function () {
-                        var evt = createMessage('message', data.substring(1), that.url);
+                        var evt = createMessage('message', data, that.url);
 
                         if (that.onmessage) {
                             that.onmessage(evt);
                         }
                         that.dispatchEvent(evt);
                     });
-                    break;
-                case 'B':
-                    taskQueue.push(function () {
-                        var evt = createMessage('message', stringToBinary(data.substring(1), that.binaryType), that.url);
+                } else {
+                    switch (data[0]) {
+                    case 'O':
+                        taskQueue.push(function () {
+                            var evt = createMessage('open');
 
-                        if (that.onmessage) {
-                            that.onmessage(evt);
-                        }
-                        that.dispatchEvent(evt);
-                    });
-                    break;
-                case 'C':
-                    taskQueue.push(function () {
-                        var evt = createMessage('close', data.substring(1));
+                            that.readyState = that.OPEN;
+                            that.protocol = data.substring(1);
+                            if (that.onopen) {
+                                that.onopen(evt);
+                            }
+                            that.dispatchEvent(evt);
+                        });
+                        break;
+                    case 'T':
+                        taskQueue.push(function () {
+                            var evt = createMessage('message', data.substring(1), that.url);
 
-                        that.readyState = that.CLOSED;
-                        if (that.onclose) {
-                            that.onclose(evt);
-                        }
-                        that.dispatchEvent(evt);
-                        delete listeners[that.__getId__()];
-                    });
-                    break;
+                            if (that.onmessage) {
+                                that.onmessage(evt);
+                            }
+                            that.dispatchEvent(evt);
+                        });
+                        break;
+                    case 'C':
+                        taskQueue.push(function () {
+                            var evt = createMessage('close', data.substring(1));
+
+                            that.readyState = that.CLOSED;
+                            if (that.onclose) {
+                                that.onclose(evt);
+                            }
+                            that.dispatchEvent(evt);
+                            delete listeners[that.__getId__()];
+                        });
+                        break;
+                    }
                 }
             }, function () {
                 taskQueue.push(function () {


### PR DESCRIPTION
Environment:
- MQTT over WebSocket uses RFC 6455, subprotocol 'mqtt' and binary payload
- Genymotion 4.2.2 and 4.3 images
- Server: Mosca (MQTT broker) + mows (MQTT over WebSocket)
- Client: mqtt.js (MQTT over WebSocket) + websocket-stream + ws

How to reproduce:
- Client send MQTT 'connect' to broker
- broker reply with MQTT 'connack' to client (0x20 0x02 0x00 0x00)
- On Android 4.4 (where native WebSocket is used), the packet is correctly parsed.
- On Addroid 4.2.2/4.3 (plugin used), packet is wrongly parsed as 'subscribe' (0x82 0x04), causing connection failure.

Why?
- WebSocket payload: 0x82 0x04 0x20 0x02 0x00 0x00
- '0x82 0x04' indicate '4-byte long binary payload'.
- JS layer gets the wrong content because 'offset' (2) and 'length' (4) is ignored by WebSocketGenerator:: onMessage
- But even if this is fixed, the 'data' received in JS layer still lacks the trailing '0x00 0x00', resulting in parse failure. Seems passing the data as String to PluginResult result in data loss.
- So the final piece is to pass as byte[] and update the handling in websocket.js
